### PR TITLE
Content Grouping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Send data to Google Analytics from the server using PHP. This library fully impl
 * Exceptions
 * Custom Dimensions / Metrics
 * Content Experiments
+* Content Grouping
 
 ## Installation
 

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -146,6 +146,9 @@ use Symfony\Component\Finder\Finder;
  * @method \TheIconic\Tracking\GoogleAnalytics\Analytics setCustomDimension($value, $index)
  * @method \TheIconic\Tracking\GoogleAnalytics\Analytics setCustomMetric($value, $index)
  *
+ * Content Grouping
+ * @method \TheIconic\Tracking\GoogleAnalytics\Analytics setContentGroup($value, $index)
+ *
  * Content Experiments
  * @method \TheIconic\Tracking\GoogleAnalytics\Analytics setExperimentId($value)
  * @method \TheIconic\Tracking\GoogleAnalytics\Analytics setExperimentVariant($value)

--- a/src/Parameters/ContentGrouping/ContentGroup.php
+++ b/src/Parameters/ContentGrouping/ContentGroup.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TheIconic\Tracking\GoogleAnalytics\Parameters\ContentGrouping;
+
+use TheIconic\Tracking\GoogleAnalytics\Parameters\SingleParameter;
+
+/**
+ * Class ContentGroup
+ *
+ * @link https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cg_
+ *
+ * @package TheIconic\Tracking\GoogleAnalytics\Parameters\ContentGroup
+ */
+class ContentGroup extends SingleParameter
+{
+    /**
+     * @inheritDoc
+     *
+     * @var string
+     */
+    protected $name = 'cg:i:';
+
+    /**
+     * @inheritDoc
+     *
+     * @return int
+     */
+    protected function maxIndex() {
+        return 5;
+    }
+}

--- a/src/Traits/Indexable.php
+++ b/src/Traits/Indexable.php
@@ -20,16 +20,20 @@ trait Indexable
     private $indexPlaceholder = ':i:';
 
     /**
-     * Maximum value index can take in GA.
-     * @var int
+     * Minimum value index can take in GA.
+     * @return int
      */
-    private $maxIndex = 200;
+    protected function minIndex() {
+        return 1;
+    }
 
     /**
-     * Minimum value index can take in GA.
-     * @var int
+     * Maximum value index can take in GA.
+     * @return int
      */
-    private $minIndex = 1;
+    protected function maxIndex() {
+        return 200;
+    }
 
     /**
      * Replaces a placeholder for the index passed.
@@ -47,7 +51,7 @@ trait Indexable
         }
 
         if (strpos($string, $this->indexPlaceholder) !== false) {
-            if (!is_numeric($index) || $index < $this->minIndex || $index > $this->maxIndex) {
+            if (!is_numeric($index) || $index < $this->minIndex() || $index > $this->maxIndex()) {
                 throw new InvalidIndexException(
                     'When setting parameter ' . get_class($this)
                     . ' a numeric index between 1 - 200 must be passed for the second argument'

--- a/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsTest.php
+++ b/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsTest.php
@@ -2,6 +2,7 @@
 
 namespace TheIconic\Tracking\GoogleAnalytics;
 
+use TheIconic\Tracking\GoogleAnalytics\Parameters\ContentGrouping\ContentGroup;
 use TheIconic\Tracking\GoogleAnalytics\Parameters\EnhancedEcommerce\Affiliation;
 use TheIconic\Tracking\GoogleAnalytics\Parameters\EnhancedEcommerce\CouponCode;
 use TheIconic\Tracking\GoogleAnalytics\Parameters\EnhancedEcommerce\Product;
@@ -253,6 +254,47 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
         $this->analytics->setHttpClient($httpClient);
 
         $this->analytics->sendPageview();
+    }
+
+    public function testContentGroupingHit()
+    {
+        $singleParameters = [
+            'v' => (new ProtocolVersion())->setValue('1'),
+            'tid' => (new TrackingId())->setValue('555'),
+            'cid' => (new ClientId())->setValue('666'),
+            't' => (new HitType())->setValue('pageview'),
+            'cg1' => (new ContentGroup(1))->setValue('group'),
+        ];
+
+        $httpClient = $this->getMock('TheIconic\Tracking\GoogleAnalytics\Network\HttpClient', ['post']);
+
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('http://www.google-analytics.com/collect'),
+                $this->equalTo($singleParameters),
+                $this->isType('array')
+            );
+
+        $this->analytics
+            ->makeNonBlocking()
+            ->setProtocolVersion('1')
+            ->setTrackingId('555')
+            ->setClientId('666')
+            ->setContentGroup('group', 1);
+
+        $this->analytics->setHttpClient($httpClient);
+
+        $this->analytics->sendPageview();
+    }
+
+    /**
+     * @expectedException \TheIconic\Tracking\GoogleAnalytics\Exception\InvalidIndexException
+     */
+    public function testInvalidContentGroupIndex()
+    {
+        $this->analytics
+            ->setContentGroup('group', 6);
     }
 
     public function testSendMegaHit()


### PR DESCRIPTION
# Added content grouping support

This is an undocumented parameter of the measurement protocol, [but it is available on the analytics.js tracker](https://support.google.com/analytics/answer/2853546).

`ga('set', 'contentGroup5', '<Group Name>');`

This will translate to a `cg5=<Group Name>` parameter on the beacon URL.

## Considerations

I had to change the `Indexable` trait as content groups are limited to just 5 and [PHP does not allow to override Traits properties](http://php.net/manual/en/language.oop5.traits.php#language.oop5.traits.properties)