### PR TITLE
[feature] Get URL from Analytics Object

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -5,6 +5,7 @@ namespace TheIconic\Tracking\GoogleAnalytics;
 use TheIconic\Tracking\GoogleAnalytics\Parameters\SingleParameter;
 use TheIconic\Tracking\GoogleAnalytics\Parameters\CompoundParameterCollection;
 use TheIconic\Tracking\GoogleAnalytics\Network\HttpClient;
+use TheIconic\Tracking\GoogleAnalytics\Network\PrepareUrl;
 use TheIconic\Tracking\GoogleAnalytics\Exception\InvalidPayloadDataException;
 
 /**
@@ -433,10 +434,24 @@ class Analytics
         }
 
         return $this->getHttpClient()->post(
+            $this->getUrl(),
+            $this->isAsyncRequest
+        );
+    }
+
+    /**
+     * Build URL used to send to Google Analytics
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        $prepareUrl = new PrepareUrl;
+
+        return $prepareUrl->build(
             $this->getEndpoint(),
             $this->singleParameters,
-            $this->compoundParametersCollections,
-            $this->isAsyncRequest
+            $this->compoundParametersCollections
         );
     }
 

--- a/src/Network/HttpClient.php
+++ b/src/Network/HttpClient.php
@@ -3,7 +3,6 @@
 namespace TheIconic\Tracking\GoogleAnalytics\Network;
 
 use TheIconic\Tracking\GoogleAnalytics\AnalyticsResponse;
-use TheIconic\Tracking\GoogleAnalytics\Parameters\General\CacheBuster;
 use TheIconic\Tracking\GoogleAnalytics\Parameters\SingleParameter;
 use TheIconic\Tracking\GoogleAnalytics\Parameters\CompoundParameterCollection;
 use GuzzleHttp\Client;
@@ -40,16 +39,6 @@ class HttpClient
     private $client;
 
     /**
-     * @var array
-     */
-    private $payloadParameters;
-
-    /**
-     * @var string
-     */
-    private $cacheBuster = '';
-
-    /**
      * Holds the promises (async responses).
      *
      * @var PromiseInterface[]
@@ -75,14 +64,6 @@ class HttpClient
     }
 
     /**
-     * @return array
-     */
-    public function getPayloadParameters()
-    {
-        return $this->payloadParameters;
-    }
-
-    /**
      * Gets HTTP client for internal class use.
      *
      * @return Client
@@ -102,26 +83,14 @@ class HttpClient
      * Sends request to Google Analytics.
      *
      * @param string $url
-     * @param SingleParameter[] $singleParameters
-     * @param CompoundParameterCollection[] $compoundParameters
      * @param boolean $nonBlocking
      * @return AnalyticsResponse
      */
-    public function post($url, array $singleParameters, array $compoundParameters, $nonBlocking = false)
+    public function post($url, $nonBlocking = false)
     {
-        $singlesPost = $this->getSingleParametersPayload($singleParameters);
-
-        $compoundsPost = $this->getCompoundParametersPayload($compoundParameters);
-
-        $this->payloadParameters = array_merge($singlesPost, $compoundsPost);
-
-        if (!empty($this->cacheBuster)) {
-            $this->payloadParameters['z'] = $this->cacheBuster;
-        }
-
         $request = new Request(
             'GET',
-            $url . '?' . http_build_query($this->payloadParameters),
+            $url,
             ['User-Agent' => self::PHP_GA_MEASUREMENT_PROTOCOL_USER_AGENT]
         );
 
@@ -150,46 +119,5 @@ class HttpClient
     protected function getAnalyticsResponse(RequestInterface $request, $response)
     {
         return new AnalyticsResponse($request, $response);
-    }
-
-    /**
-     * Prepares all the Single Parameters to be sent to GA.
-     *
-     * @param SingleParameter[] $singleParameters
-     * @return array
-     */
-    private function getSingleParametersPayload(array $singleParameters)
-    {
-        $postData = [];
-        $cacheBuster = new CacheBuster();
-
-        foreach ($singleParameters as $parameterObj) {
-            if ($parameterObj->getName() === $cacheBuster->getName()) {
-                $this->cacheBuster = $parameterObj->getValue();
-                continue;
-            }
-
-            $postData[$parameterObj->getName()] = $parameterObj->getValue();
-        }
-
-        return $postData;
-    }
-
-    /**
-     * Prepares compound parameters inside collections to be sent to GA.
-     *
-     * @param CompoundParameterCollection[] $compoundParameters
-     * @return array
-     */
-    private function getCompoundParametersPayload(array $compoundParameters)
-    {
-        $postData = [];
-
-        foreach ($compoundParameters as $compoundCollection) {
-            $parameterArray = $compoundCollection->getParametersArray();
-            $postData = array_merge($postData, $parameterArray);
-        }
-
-        return $postData;
     }
 }

--- a/src/Network/PrepareUrl.php
+++ b/src/Network/PrepareUrl.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace TheIconic\Tracking\GoogleAnalytics\Network;
+
+use TheIconic\Tracking\GoogleAnalytics\Parameters\General\CacheBuster;
+
+/**
+ * Class PrepareUrl
+ *
+ * @package TheIconic\Tracking\GoogleAnalytics
+ */
+class PrepareUrl
+{
+    /**
+     * @var array
+     */
+    private $payloadParameters;
+
+    /**
+     * @var string
+     */
+    private $cacheBuster = '';
+
+    /**
+     * Build URL which is sent to Google Analytics
+     *
+     * @param string $url
+     * @param SingleParameter[] $singleParameters
+     * @param CompoundParameterCollection[] $compoundParameters
+     * @return string
+     */
+    public function build($url, array $singleParameters, array $compoundParameters)
+    {
+        $singlesPost = $this->getSingleParametersPayload($singleParameters);
+
+        $compoundsPost = $this->getCompoundParametersPayload($compoundParameters);
+
+        $this->payloadParameters = array_merge($singlesPost, $compoundsPost);
+
+        if (!empty($this->cacheBuster)) {
+            $this->payloadParameters['z'] = $this->cacheBuster;
+        }
+
+        return $url . '?' . http_build_query($this->payloadParameters);
+    }
+
+    /**
+     * @return array
+     */
+    public function getPayloadParameters()
+    {
+        return $this->payloadParameters;
+    }
+
+    /**
+     * Prepares all the Single Parameters to be sent to GA.
+     *
+     * @param SingleParameter[] $singleParameters
+     * @return array
+     */
+    private function getSingleParametersPayload(array $singleParameters)
+    {
+        $postData = [];
+        $cacheBuster = new CacheBuster();
+
+        foreach ($singleParameters as $parameterObj) {
+            if ($parameterObj->getName() === $cacheBuster->getName()) {
+                $this->cacheBuster = $parameterObj->getValue();
+                continue;
+            }
+
+            $postData[$parameterObj->getName()] = $parameterObj->getValue();
+        }
+
+        return $postData;
+    }
+
+    /**
+     * Prepares compound parameters inside collections to be sent to GA.
+     *
+     * @param CompoundParameterCollection[] $compoundParameters
+     * @return array
+     */
+    private function getCompoundParametersPayload(array $compoundParameters)
+    {
+        $postData = [];
+
+        foreach ($compoundParameters as $compoundCollection) {
+            $parameterArray = $compoundCollection->getParametersArray();
+            $postData = array_merge($postData, $parameterArray);
+        }
+
+        return $postData;
+    }
+}

--- a/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsTest.php
+++ b/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsTest.php
@@ -183,19 +183,18 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
     {
         $httpClient = $this->getMock('TheIconic\Tracking\GoogleAnalytics\Network\HttpClient', ['post']);
 
-        $httpClient->expects($this->once())
-            ->method('post')
-            ->with(
-                $this->equalTo('http://www.google-analytics.com/collect'),
-                $this->isType('array'),
-                $this->isType('array')
-            );
-
         $this->analytics
             ->setProtocolVersion('1')
             ->setTrackingId('555')
             ->setClientId('666')
-            ->setDocumentPath('\thepage');
+            ->setDocumentPath('\thepage')
+            ->setHitType('pageview');
+
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo($this->analytics->getUrl())
+            );
 
         $this->analytics->setHttpClient($httpClient);
 
@@ -206,20 +205,19 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
     {
         $httpClient = $this->getMock('TheIconic\Tracking\GoogleAnalytics\Network\HttpClient', ['post']);
 
-        $httpClient->expects($this->once())
-            ->method('post')
-            ->with(
-                $this->equalTo('https://ssl.google-analytics.com/collect'),
-                $this->isType('array'),
-                $this->isType('array')
-            );
-
         $this->analyticsSsl
             ->setAsyncRequest(true)
             ->setProtocolVersion('1')
             ->setTrackingId('555')
             ->setClientId('666')
-            ->setDocumentPath('\mypage');
+            ->setDocumentPath('\mypage')
+            ->setHitType('pageview');
+
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo($this->analyticsSsl->getUrl())
+            );
 
         $this->analyticsSsl->setHttpClient($httpClient);
 
@@ -230,20 +228,19 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
     {
         $httpClient = $this->getMock('TheIconic\Tracking\GoogleAnalytics\Network\HttpClient', ['post']);
 
-        $httpClient->expects($this->once())
-            ->method('post')
-            ->with(
-                $this->equalTo('http://www.google-analytics.com/debug/collect'),
-                $this->isType('array'),
-                $this->isType('array')
-            );
-
         $this->analytics
             ->setDebug(true)
             ->setProtocolVersion('1')
             ->setTrackingId('555')
             ->setClientId('666')
-            ->setDocumentPath('\mypage');
+            ->setDocumentPath('\mypage')
+            ->setHitType('pageview');
+
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo($this->analytics->getUrl())
+            );
 
         $this->analytics->setHttpClient($httpClient);
 
@@ -254,20 +251,19 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
     {
         $httpClient = $this->getMock('TheIconic\Tracking\GoogleAnalytics\Network\HttpClient', ['post']);
 
-        $httpClient->expects($this->once())
-            ->method('post')
-            ->with(
-                $this->equalTo('https://ssl.google-analytics.com/collect'),
-                $this->isType('array'),
-                $this->isType('array')
-            );
-
         $this->analyticsSsl
             ->setUserTiminCategory('hehe')
             ->setProtocolVersion('1')
             ->setTrackingId('555')
             ->setClientId('666')
-            ->setDocumentPath('\mypage');
+            ->setDocumentPath('\mypage')
+            ->setHitType('pageview');
+
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo($this->analyticsSsl->getUrl())
+            );
 
         $this->analyticsSsl->setHttpClient($httpClient);
 
@@ -283,21 +279,20 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
             't' => (new HitType())->setValue('pageview'),
         ];
 
+        $this->analytics
+            ->makeNonBlocking()
+            ->setProtocolVersion('1')
+            ->setTrackingId('555')
+            ->setClientId('666')
+            ->setHitType('pageview');
+
         $httpClient = $this->getMock('TheIconic\Tracking\GoogleAnalytics\Network\HttpClient', ['post']);
 
         $httpClient->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('http://www.google-analytics.com/collect'),
-                $this->equalTo($singleParameters),
-                $this->isType('array')
+                $this->equalTo($this->analytics->getUrl())
             );
-
-        $this->analytics
-            ->makeNonBlocking()
-            ->setProtocolVersion('1')
-            ->setTrackingId('555')
-            ->setClientId('666');
 
         $this->analytics->setHttpClient($httpClient);
 
@@ -314,22 +309,23 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
             'cg1' => (new ContentGroup(1))->setValue('group'),
         ];
 
-        $httpClient = $this->getMock('TheIconic\Tracking\GoogleAnalytics\Network\HttpClient', ['post']);
-
-        $httpClient->expects($this->once())
-            ->method('post')
-            ->with(
-                $this->equalTo('http://www.google-analytics.com/collect'),
-                $this->equalTo($singleParameters),
-                $this->isType('array')
-            );
-
         $this->analytics
             ->makeNonBlocking()
             ->setProtocolVersion('1')
             ->setTrackingId('555')
             ->setClientId('666')
-            ->setContentGroup('group', 1);
+            ->setContentGroup('group', 1)
+            ->setHitType('pageview');
+
+        $httpClient = $this->getMock('TheIconic\Tracking\GoogleAnalytics\Network\HttpClient', ['post']);
+
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo($this->analytics->getUrl())
+            );
+
+
 
         $this->analytics->setHttpClient($httpClient);
 
@@ -386,7 +382,8 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
             ->setRevenue(250.0)
             ->setTax(25.0)
             ->setShipping(15.0)
-            ->setCouponCode('MY_COUPON');
+            ->setCouponCode('MY_COUPON')
+            ->setHitType('event');
 
 
         $productData1 = [
@@ -432,9 +429,10 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
         $httpClient->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('http://www.google-analytics.com/collect'),
-                $this->equalTo($singleParameters),
-                $this->equalTo($compoundParameters)
+                $this->equalTo($this->analytics->getUrl())
+                // $this->equalTo('http://www.google-analytics.com/collect'),
+                // $this->equalTo($singleParameters),
+                // $this->equalTo($compoundParameters)
             );
 
         $this->analytics->setHttpClient($httpClient);

--- a/tests/TheIconic/Tracking/GoogleAnalytics/Network/HttpClientTest.php
+++ b/tests/TheIconic/Tracking/GoogleAnalytics/Network/HttpClientTest.php
@@ -62,56 +62,15 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
     public function testPost()
     {
-        $singleParameter = new SingleTestParameter();
-        $singleParameter->setValue('hey');
-        $singleParameterIdx = new SingleTestParameterIndexed(4);
-        $singleParameterIdx->setValue(9);
-        $cacheBuster = new CacheBuster();
-        $cacheBuster->setValue('123');
-        $singles = [$singleParameter, $cacheBuster, $singleParameterIdx];
-
-        $compoundCollection = new CompoundParameterTestCollection(6);
-        $compoundParameter = new CompoundTestParameter(['sku' => 555, 'name' => 'cathy']);
-        $compoundCollection->add($compoundParameter);
-        $compoundParameter2 = new CompoundTestParameter(['sku' => 666, 'name' => 'isa']);
-        $compoundCollection->add($compoundParameter2);
-        $compounds = [$compoundCollection];
-
-
-        $response = $this->mockHttpClient->post('http://test-collector.com', $singles, $compounds);
+        $response = $this->mockHttpClient->post('http://test-collector.com/collect?v=1');
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
 
-        $responseAsync = $this->mockHttpClient->post('http://test-collector.com', $singles, $compounds, true);
+        $responseAsync = $this->mockHttpClient->post('http://test-collector.com/collect?v=1', true);
         $this->assertInstanceOf('GuzzleHttp\Promise\PromiseInterface', $responseAsync);
 
-        $response = $this->httpClient->post('http://test-collector.com', $singles, $compounds);
+        $response = $this->httpClient->post('http://test-collector.com/collect?v=1');
 
         $this->assertInstanceOf('TheIconic\Tracking\GoogleAnalytics\AnalyticsResponse', $response);
-
-        $payload = $this->httpClient->getPayloadParameters();
-
-        $expect = [
-            'test' => 'hey',
-            'testi4' => 9,
-            'cp6t1id' => 555,
-            'cp6t1nm' => 'cathy',
-            'cp6t2id' => 666,
-            'cp6t2nm' => 'isa',
-            'z' => '123'
-        ];
-
-        $this->assertEquals($expect, $payload);
-
-        // assets cache buster is last element
-        $count = 1;
-        foreach ($payload as $key => $value) {
-            if ($count === 7) {
-                $this->assertEquals('z', $key);
-                $this->assertEquals('123', $value);
-            }
-
-            $count++;
-        }
 
         // Promises should be unwrapped on the object destruction
         $this->httpClient = null;

--- a/tests/TheIconic/Tracking/GoogleAnalytics/Network/PrepareUrlTest.php
+++ b/tests/TheIconic/Tracking/GoogleAnalytics/Network/PrepareUrlTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace TheIconic\Tracking\GoogleAnalytics\Network;
+
+use TheIconic\Tracking\GoogleAnalytics\Network\PrepareUrl;
+use TheIconic\Tracking\GoogleAnalytics\Parameters\General\CacheBuster;
+use TheIconic\Tracking\GoogleAnalytics\Tests\CompoundParameterTestCollection;
+use TheIconic\Tracking\GoogleAnalytics\Tests\CompoundTestParameter;
+use TheIconic\Tracking\GoogleAnalytics\Tests\SingleTestParameter;
+use TheIconic\Tracking\GoogleAnalytics\Tests\SingleTestParameterIndexed;
+
+class PrepareUrlTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBuild()
+    {
+        $prepareUrl = new PrepareUrl;
+
+        $singleParameter = new SingleTestParameter();
+        $singleParameter->setValue('foo');
+        $singleParameterIdx = new SingleTestParameterIndexed(4);
+        $singleParameterIdx->setValue(9);
+        $cacheBuster = new CacheBuster();
+        $cacheBuster->setValue('123');
+        $singles = [$singleParameter, $cacheBuster, $singleParameterIdx];
+
+        $compoundCollection = new CompoundParameterTestCollection(6);
+        $compoundParameter = new CompoundTestParameter(['sku' => 555, 'name' => 'cathy']);
+        $compoundCollection->add($compoundParameter);
+        $compoundParameter2 = new CompoundTestParameter(['sku' => 666, 'name' => 'isa']);
+        $compoundCollection->add($compoundParameter2);
+        $compounds = [$compoundCollection];
+
+        $url = $prepareUrl->build('http://test-collector.com', $singles, $compounds);
+
+        $payload = $prepareUrl->getPayloadParameters();
+
+        $expect = [
+            'test' => 'foo',
+            'testi4' => 9,
+            'cp6t1id' => 555,
+            'cp6t1nm' => 'cathy',
+            'cp6t2id' => 666,
+            'cp6t2nm' => 'isa',
+            'z' => '123'
+        ];
+
+        $this->assertEquals($expect, $payload);
+
+        // assets cache buster is last element
+        $count = 1;
+        foreach ($payload as $key => $value) {
+            if ($count === 7) {
+                $this->assertEquals('z', $key);
+                $this->assertEquals('123', $value);
+            }
+
+            $count++;
+        }
+    }
+
+}


### PR DESCRIPTION
This PR changes how the "final" Google Analytics Request URL is built. 
The goal of this PR is to expose the Request URL to the Analytics Object, so it can be used in other ways (e.g to create Email-Tracking Pixels as described [here](https://developers.google.com/analytics/devguides/collection/protocol/v1/email).)

Also see Issue #18 

## Todo

- [x] Keep Coverage at 100%
- [x] Add missing tests

## Usage

```php
use TheIconic\Tracking\GoogleAnalytics\Analytics;

$analytics = new Analytics(true);

$analytics
    ->setProtocolVersion('1')
    ->setTrackingId('UA-26293728-11')
    ->setClientId('12345678')
    ->setDocumentPath('/mypage')
    ->setIpOverride("202.126.106.175");

$url = $analytics->getUrl();
```

I'm open to any feedback to my first big PR on an open source project :)

