### PR TITLE
Modify encode type

### DIFF
--- a/src/Network/PrepareUrl.php
+++ b/src/Network/PrepareUrl.php
@@ -45,8 +45,8 @@ class PrepareUrl
         if (!empty($this->cacheBuster)) {
             $this->payloadParameters['z'] = $this->cacheBuster;
         }
-
-        return $url . '?' . http_build_query($this->payloadParameters);
+        $query = http_build_query($this->payloadParameters, null, ini_get('arg_separator.output'), PHP_QUERY_RFC3986);
+        return $url . '?' . $query;
     }
 
     /**


### PR DESCRIPTION
Hello, I tried to send search keyword in Japanese by this library, but the search keyword corrupted.
I think request parameters to send to Google Analytics must be encoded based on RFC3986.
space must be `%20`, not `+`.
I modified encode type of `http_build_query()` from RFC1738 to RFC3986.
