### PR TITLE
Disabling requests to GA

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -467,7 +467,7 @@ class Analytics
         }
 
         if (!is_bool($isDisabled)) {
-            throw new \InvalidArgumentException('Secondt constructor argument "isDisabled" must be boolean');
+            throw new \InvalidArgumentException('Second constructor argument "isDisabled" must be boolean');
         }
 
         if ($isSsl) {
@@ -475,9 +475,7 @@ class Analytics
             $this->endpoint = str_replace('www', 'ssl', $this->endpoint);
         }
         
-        if ($isDisabled) {
-            $this->isDisabled = true;
-        }
+		$this->isDisabled = $isDisabled;
     }
 
     /**
@@ -584,12 +582,14 @@ class Analytics
             throw new InvalidPayloadDataException();
         }
 
-        if (!$this->isDisabled) {
+        if ($this->isDisabled) {
+			return new NullAnalyticsResponse();
+        } else {
             return $this->getHttpClient()->post(
                 $this->getUrl(),
                 $this->isAsyncRequest
             );
-        }
+		}
     }
 
     /**

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -348,6 +348,14 @@ class Analytics
     protected $httpClient;
 
     /**
+     * Indicates if the request to GA will be executed (by default) or not.
+     *
+     * @var boolean
+     */
+    protected $isDisabled = false;
+
+    
+    /**
      * Initializes to a list of all the available parameters to be sent in a hit.
      *
      * @var array
@@ -452,15 +460,23 @@ class Analytics
      * @param bool $isSsl
      * @throws \InvalidArgumentException
      */
-    public function __construct($isSsl = false)
+    public function __construct($isSsl = false, $isDisabled = false)
     {
         if (!is_bool($isSsl)) {
             throw new \InvalidArgumentException('First constructor argument "isSSL" must be boolean');
         }
 
+        if (!is_bool($isDisabled)) {
+            throw new \InvalidArgumentException('Secondt constructor argument "isDisabled" must be boolean');
+        }
+
         if ($isSsl) {
             $this->uriScheme .= 's';
             $this->endpoint = str_replace('www', 'ssl', $this->endpoint);
+        }
+        
+        if ($isDisabled) {
+            $this->isDisabled = true;
         }
     }
 
@@ -568,10 +584,12 @@ class Analytics
             throw new InvalidPayloadDataException();
         }
 
-        return $this->getHttpClient()->post(
-            $this->getUrl(),
-            $this->isAsyncRequest
-        );
+        if (!$this->isDisabled) {
+            return $this->getHttpClient()->post(
+                $this->getUrl(),
+                $this->isAsyncRequest
+            );
+        }
     }
 
     /**

--- a/src/AnalyticsResponse.php
+++ b/src/AnalyticsResponse.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Promise\PromiseInterface;
  *
  * @package TheIconic\Tracking\GoogleAnalytics
  */
-class AnalyticsResponse
+class AnalyticsResponse implements AnalyticsResponseInterface
 {
     /**
      * HTTP status code for the response.

--- a/src/AnalyticsResponseInterface.php
+++ b/src/AnalyticsResponseInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace TheIconic\Tracking\GoogleAnalytics;
+
+/**
+ * Interface AnalyticsResponseInterface
+ * 
+ * @package TheIconic\Tracking\GoogleAnalytics
+ */
+interface AnalyticsResponseInterface
+{
+	/**
+	 * Gets the HTTP status code.
+	 *
+	 * @api
+	 * @return null|int
+	 */
+	public function getHttpStatusCode();
+
+	/**
+	 * Gets the request URI used to get the response.
+	 *
+	 * @api
+	 * @return null|string
+	 */
+	public function getRequestUrl();
+
+	/**
+	 * Gets the debug response.
+	 *
+	 * @api
+	 * @return array
+	 */
+	public function getDebugResponse();
+}

--- a/src/NullAnalyticsResponse.php
+++ b/src/NullAnalyticsResponse.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace TheIconic\Tracking\GoogleAnalytics;
+
+/**
+ * Represents the null-response object
+ *
+ * @package TheIconic\Tracking\GoogleAnalytics
+ */
+class NullAnalyticsResponse implements AnalyticsResponseInterface
+{
+    /**
+     * It returns NULL as it is null-object.
+     *
+     * @api
+     * @return null
+     */
+    public function getHttpStatusCode()
+    {
+        return null;
+    }
+
+    /**
+     * It returns NULL as it is null-object.
+     *
+     * @api
+     * @return null
+     */
+    public function getRequestUrl()
+    {
+        return null;
+    }
+
+    /**
+     * Returns empty array as it is null-object.
+     *
+     * @api
+     * @return array
+     */
+    public function getDebugResponse()
+    {
+        return [];
+    }
+}

--- a/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsTest.php
+++ b/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsTest.php
@@ -70,11 +70,6 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('TheIconic\Tracking\GoogleAnalytics\Analytics', $sslAnalytics);
     }
 
-    public function testDisableArgument()
-    {
-        $analytics = new Analytics(false, true);
-    }
-
     public function testSetParameter()
     {
         $response = $this->analytics
@@ -191,6 +186,27 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
     public function testSetInvalidProductAction()
     {
         $this->analytics->setProductActionToPurchae();
+    }
+
+    public function testDisbablingSend()
+    {
+		$analyticsDisabled = new Analytics(false, true);
+		$analyticsDisabled
+            ->setProtocolVersion('1')
+            ->setTrackingId('555')
+            ->setClientId('666')
+            ->setDocumentPath('\thepage')
+            ->setHitType('pageview');
+
+		$result = $analyticsDisabled->sendPageview();
+		$this->assertInstanceOf(
+			'TheIconic\Tracking\GoogleAnalytics\NullAnalyticsResponse',
+			$result
+		);
+
+		$this->assertNull($result->getHttpStatusCode());
+		$this->assertNull($result->getRequestUrl());
+		$this->assertEquals([], $result->getDebugResponse());
     }
 
     public function testSendSimpleHit()

--- a/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsTest.php
+++ b/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsTest.php
@@ -55,10 +55,24 @@ class AnalyticsTest extends \PHPUnit_Framework_TestCase
         (new Analytics('1'));
     }
 
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidClassInitialization2()
+    {
+        (new Analytics(false, '1'));
+    }
+
     public function testHttpsEndpoint()
     {
         $sslAnalytics = new Analytics(true);
         $this->assertInstanceOf('TheIconic\Tracking\GoogleAnalytics\Analytics', $sslAnalytics);
+    }
+
+    public function testDisableArgument()
+    {
+        $analytics = new Analytics(false, true);
     }
 
     public function testSetParameter()


### PR DESCRIPTION
In development environment it is useful to disable any requests to GA, because they don't have any sence.
Instead of setting the fake tracking id (which in fact does not block requests to GA) new constructor parameter was implemented.