### PR TITLE
Remove HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - "5.5"
   - "5.6"
   - "7"
-  - hhvm
 install:
   - composer install
   - composer dump-autoload -o


### PR DESCRIPTION
* Composer no longer supports it, so we can no longer support it as well as it won't run in CI