### PR TITLE
Add support for Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.7.*",


### PR DESCRIPTION
Please merge this ASAP as Laravel 8 is releasing today and as you know, [Laravel GAMP](https://github.com/irazasyed/laravel-gamp) is dependent on this library. Laravel 8 requires Guzzle 7, so until this PR is merged, users of Laravel GAMP won't be able to use the package in Laravel 8.

I checked the libs code to see if there could be any issues in upgrading to Guzzle 7 but so far found none that could break it but I haven't tested this yet.