### PR TITLE
Automatically send batch request

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -3,7 +3,6 @@
 namespace TheIconic\Tracking\GoogleAnalytics;
 
 use BadMethodCallException;
-use TheIconic\Tracking\GoogleAnalytics\Exception\EnqueueUrlsOverflowException;
 use TheIconic\Tracking\GoogleAnalytics\Exception\InvalidPayloadDataException;
 use TheIconic\Tracking\GoogleAnalytics\Network\HttpClient;
 use TheIconic\Tracking\GoogleAnalytics\Network\PrepareUrl;
@@ -327,7 +326,6 @@ class Analytics
      * @var string
      */
     protected $batchEndpoint = '://www.google-analytics.com/batch';
-     
 
     /**
      * Indicates if the request is in debug mode(validating hits).
@@ -373,7 +371,7 @@ class Analytics
      * @var array
      */
     protected $options = [];
-    
+
     /**
      * Initializes to a list of all the available parameters to be sent in a hit.
      *
@@ -622,8 +620,9 @@ class Analytics
     protected function enqueueHit($methodName)
     {
 
-        if(count($this->enqueuedUrls) == 20) {
-            throw new EnqueueUrlsOverflowException();
+        if (count($this->enqueuedUrls) == 20) {
+            $this->sendEnqueuedHits();
+            $this->enqueuedUrls = [];
         }
 
         $hitType = strtoupper(substr($methodName, 7));
@@ -643,7 +642,7 @@ class Analytics
      */
     protected function setAndValidateHit($hitType)
     {
-        
+
         $hitConstant = $this->getParameterClassConstant(
             'TheIconic\Tracking\GoogleAnalytics\Parameters\Hit\HitType::HIT_TYPE_' . $hitType,
             'Hit type ' . $hitType . ' is not defined, check spelling'
@@ -698,7 +697,7 @@ class Analytics
      */
     public function getUrl($onlyQuery = false)
     {
-        $prepareUrl = new PrepareUrl;
+        $prepareUrl = new PrepareUrl();
 
         return $prepareUrl->build(
             $this->getEndpoint(),
@@ -948,6 +947,16 @@ class Analytics
         $this->enqueuedUrls = [];
 
         return $this;
+    }
+
+    /**
+     * Determine if enqueued urls are present
+     *
+     * @return bool
+     */
+    public function hasEnqueuedUrls()
+    {
+        return count($this->enqueuedUrls) > 0;
     }
 
     /**

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -622,7 +622,6 @@ class Analytics
 
         if (count($this->enqueuedUrls) == 20) {
             $this->sendEnqueuedHits();
-            $this->enqueuedUrls = [];
         }
 
         $hitType = strtoupper(substr($methodName, 7));


### PR DESCRIPTION
Hi, first of all thank you @alberto-bottarini for creating the batch functionality. 

In the discussion of #83 @jorgeborges said he would prefer the batch to be sent automatically after the 20 enqueued url's have been reached. Personally I like this approach so this is why i'm creating this pull request. 

I've also added a hasEnqueuedUrls method. This method allows us to determine if any enqueued url's are still available before sending the response back to the client. If any are available then send the enqueued hits. We're using Laravel so I created a middleware to do exactly that for each response. 

This way we don't have to worry about the limit. 

It would be nice to have at least the hasEnqueuedUrls method added. I understand the philosophy behind the exception approach as well, if you decide to keep it that way than i will create something myself.

I coudn't get phpunit to work, i got the following error: 

![image](https://user-images.githubusercontent.com/15109384/94674957-4153aa80-0319-11eb-91ac-7e2fa9f391cd.png)

I'll check them again if they do not pass. 
