### PR TITLE
Fixes issue with http_build_query() on PHP 8.1

### DIFF
--- a/src/Network/PrepareUrl.php
+++ b/src/Network/PrepareUrl.php
@@ -45,7 +45,7 @@ class PrepareUrl
         if (!empty($this->cacheBuster)) {
             $this->payloadParameters['z'] = $this->cacheBuster;
         }
-        $query = http_build_query($this->payloadParameters, null, ini_get('arg_separator.output'), PHP_QUERY_RFC3986);
+        $query = http_build_query($this->payloadParameters, "", ini_get('arg_separator.output'), PHP_QUERY_RFC3986);
         return $onlyQuery ? $query : ($url . '?' . $query);
     }
 


### PR DESCRIPTION
http_build_query(): Passing null to parameter #2 ($numeric_prefix) of
type string is deprecated