### PR TITLE
Add ability to get reason phrase

### DIFF
--- a/src/AnalyticsResponse.php
+++ b/src/AnalyticsResponse.php
@@ -37,6 +37,13 @@ class AnalyticsResponse implements AnalyticsResponseInterface
     protected $responseBody;
 
     /**
+     * Reason phrase.
+     *
+     * @var string
+     */
+    protected $reasonPhrase;
+
+    /**
      * Gets the relevant data from the Guzzle clients.
      *
      * @param RequestInterface $request
@@ -47,9 +54,11 @@ class AnalyticsResponse implements AnalyticsResponseInterface
         if ($response instanceof ResponseInterface) {
             $this->httpStatusCode = $response->getStatusCode();
             $this->responseBody = $response->getBody()->getContents();
+            $this->reasonPhrase = $response->getReasonPhrase();
         } elseif ($response instanceof PromiseInterface) {
             $this->httpStatusCode = null;
             $this->responseBody = null;
+            $this->reasonPhrase = null;
         } else {
             throw new \InvalidArgumentException(
                 'Second constructor argument "response" must be instance of ResponseInterface or PromiseInterface'
@@ -69,6 +78,17 @@ class AnalyticsResponse implements AnalyticsResponseInterface
     public function getHttpStatusCode()
     {
         return $this->httpStatusCode;
+    }
+
+    /**
+     * Gets the HTTP reason phrase.
+     *
+     * @api
+     * @return string
+     */
+    public function getReasonPhrase()
+    {
+        return $this->reasonPhrase;
     }
 
     /**

--- a/src/AnalyticsResponseInterface.php
+++ b/src/AnalyticsResponseInterface.php
@@ -18,6 +18,14 @@ interface AnalyticsResponseInterface
     public function getHttpStatusCode();
 
     /**
+     * Gets the HTTP reason phrase.
+     *
+     * @api
+     * @return string
+     */
+    public function getReasonPhrase();
+
+    /**
      * Gets the request URI used to get the response.
      *
      * @api

--- a/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsResponseTest.php
+++ b/tests/TheIconic/Tracking/GoogleAnalytics/AnalyticsResponseTest.php
@@ -59,6 +59,15 @@ class AnalyticsResponseTest extends \PHPUnit_Framework_TestCase
             ->method('getUri')
             ->will($this->returnValue(new Uri('http://test-collector/hello')));
 
+        $this->mockRequest = $this->getMockBuilder('GuzzleHttp\Psr7\Request')
+            ->setMethods(['getUri'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockRequest->expects($this->atLeast(1))
+            ->method('getReasonPhrase')
+            ->will($this->returnValue("ReasonPhrase"));
+
         $this->analyticsResponse = new AnalyticsResponse($this->mockRequest, $mockResponse);
 
 
@@ -105,6 +114,12 @@ class AnalyticsResponseTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('200', $this->analyticsResponse->getHttpStatusCode());
         $this->assertEquals(null, $this->analyticsResponseAsync->getHttpStatusCode());
+    }
+
+    public function testGetReasonPhrase()
+    {
+        $this->assertEquals('ReasonPhrase', $this->analyticsResponse->getReasonPhrase());
+        $this->assertEquals('ReasonPhrase', $this->analyticsResponseAsync->getReasonPhrase());
     }
 
     public function testGetUrl()


### PR DESCRIPTION
This adds the ability to get the HTTP reason phrase from the original response so that the developer may handle errors with the same status codes on an individual basis. 

https://developers.google.com/analytics/devguides/reporting/core/v4/errors

I was not able to execute the tests using PHP 8.1 on my system (Manjaro) getting the following error seemingly related to the older PHPUnit version but I was unable to update and unsuccessful with yoast/phpunit-polyfills installed so just hoping the PR works. Feel free to edit. :-) 

```bash
PHP Fatal error:  Uncaught Error: Call to undefined function each() in /home/darron/webdev/php-ga-measurement-protocol/vendor/phpunit/phpunit/src/Util/Getopt.php:38
```
