### PR TITLE
PHP 8.1 - Updating the call to http_build_query

### DIFF
--- a/src/Network/PrepareUrl.php
+++ b/src/Network/PrepareUrl.php
@@ -45,7 +45,7 @@ class PrepareUrl
         if (!empty($this->cacheBuster)) {
             $this->payloadParameters['z'] = $this->cacheBuster;
         }
-        $query = http_build_query($this->payloadParameters, null, ini_get('arg_separator.output'), PHP_QUERY_RFC3986);
+        $query = http_build_query($this->payloadParameters, '', ini_get('arg_separator.output'), PHP_QUERY_RFC3986);
         return $onlyQuery ? $query : ($url . '?' . $query);
     }
 


### PR DESCRIPTION
The function signature has changed and PHP 8.1 requires the second parameter to be an empty string rather than `null` - https://www.php.net/manual/en/function.http-build-query.php